### PR TITLE
Fixing xpath-filter pageUrlFilterRegex

### DIFF
--- a/nutch-plugins/filter-xpath/src/main/java/com/atlantbh/nutch/filter/xpath/FilterUtils.java
+++ b/nutch-plugins/filter-xpath/src/main/java/com/atlantbh/nutch/filter/xpath/FilterUtils.java
@@ -7,6 +7,12 @@ import org.w3c.dom.Node;
 
 public class FilterUtils {
 	
+  /**
+   * Delimeter to separate the property and the property field so we know
+   * which property the field is associated to
+   */
+  public static final String DELIMTER = "|*|";
+  
 	/**
 	 * Returns the same value. If null returns the defaultValue.
 	 * 

--- a/nutch-plugins/filter-xpath/src/main/java/com/atlantbh/nutch/filter/xpath/XPathHtmlParserFilter.java
+++ b/nutch-plugins/filter-xpath/src/main/java/com/atlantbh/nutch/filter/xpath/XPathHtmlParserFilter.java
@@ -174,9 +174,9 @@ public class XPathHtmlParserFilter implements HtmlParseFilter {
 								}
 							}
 							
-							// Add the extracted data to meta
+							// Add the extracted data to meta prepended with the property id
 							if(value != null) {
-								metadata.add(xPathIndexerPropertiesField.getName(), value);
+								metadata.add(xPathIndexerProperties.getId() + FilterUtils.DELIMTER + xPathIndexerPropertiesField.getName(), value);
 							}
 							
 						} else {
@@ -184,11 +184,11 @@ public class XPathHtmlParserFilter implements HtmlParseFilter {
 							// Iterate trough all found nodes
 							for (Object node : nodeList) {
 
-								// Add the extracted data to meta
+							  // Add the extracted data to meta prepended with the property id
 								String value = FilterUtils.extractTextContentFromRawNode(node);					
 								value = filterValue(value, trim);
 								if(value != null) {
-									metadata.add(xPathIndexerPropertiesField.getName(), value);	
+									metadata.add(xPathIndexerProperties.getId() + FilterUtils.DELIMTER + xPathIndexerPropertiesField.getName(), value);
 								}
 							}
 						}

--- a/nutch-plugins/filter-xpath/src/main/java/com/atlantbh/nutch/filter/xpath/XPathIndexingFilter.java
+++ b/nutch-plugins/filter-xpath/src/main/java/com/atlantbh/nutch/filter/xpath/XPathIndexingFilter.java
@@ -74,7 +74,7 @@ public class XPathIndexingFilter implements IndexingFilter {
 				for(XPathIndexerPropertiesField xPathIndexerPropertiesField : xPathIndexerPropertiesFieldList) {
 					
 					FieldType type = xPathIndexerPropertiesField.getType();
-					for(String stringValue : metadata.getValues(xPathIndexerPropertiesField.getName())) {
+					for(String stringValue : metadata.getValues(xPathIndexerProperties.getId() + FilterUtils.DELIMTER + xPathIndexerPropertiesField.getName())) {
 						
 						Object value;
 						switch(type) {

--- a/nutch-plugins/filter-xpath/src/main/java/com/atlantbh/nutch/filter/xpath/config/XPathIndexerProperties.java
+++ b/nutch-plugins/filter-xpath/src/main/java/com/atlantbh/nutch/filter/xpath/config/XPathIndexerProperties.java
@@ -23,7 +23,7 @@ public class XPathIndexerProperties {
 		this.xPathIndexerPropertiesFieldList = xPathIndexerPropertiesFieldList;
 	}
 	
-	@XmlAttribute(name="urlFilterRegex", required=false)
+	@XmlAttribute(name="pageUrlFilterRegex", required=false)
 	public String getPageUrlFilterRegex() {
 		return pageUrlFilterRegex;
 	}

--- a/nutch-plugins/filter-xpath/src/main/java/com/atlantbh/nutch/filter/xpath/config/XPathIndexerProperties.java
+++ b/nutch-plugins/filter-xpath/src/main/java/com/atlantbh/nutch/filter/xpath/config/XPathIndexerProperties.java
@@ -9,6 +9,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 public class XPathIndexerProperties {
 
+  private String id;
 	private String pageUrlFilterRegex;
 	private Boolean trimPageContentFilterXPathData;
 	private String pageContentFilterXPath;
@@ -21,6 +22,14 @@ public class XPathIndexerProperties {
 	
 	public XPathIndexerProperties(List<XPathIndexerPropertiesField> xPathIndexerPropertiesFieldList) {
 		this.xPathIndexerPropertiesFieldList = xPathIndexerPropertiesFieldList;
+	}
+	@XmlAttribute(name="id", required=true)
+	public String getId() {
+	  return id;
+	}
+	
+	public void setId(String id) {
+	  this.id = id;
 	}
 	
 	@XmlAttribute(name="pageUrlFilterRegex", required=false)


### PR DESCRIPTION
Changing the regex filter xml attribute name from urlFilterRegex to
pageUrlFilterRegex to match the documentation.

Fixes #6
